### PR TITLE
Change error handling

### DIFF
--- a/src/typed.jl
+++ b/src/typed.jl
@@ -63,7 +63,7 @@ function dispatch_msg(x::JSONRPCEndpoint, dispatcher::MsgDispatcher, msg)
             end
         catch err
             if err isa JSONRPCError
-                send_error_response(x, msg, err.code, err.message, err.data)
+                send_error_response(x, msg, err.code, err.msg, err.data)
             else
                 rethrow(err)
             end

--- a/src/typed.jl
+++ b/src/typed.jl
@@ -52,20 +52,16 @@ function dispatch_msg(x::JSONRPCEndpoint, dispatcher::MsgDispatcher, msg)
     method_name = msg["method"]
     handler = get(dispatcher._handlers, method_name, nothing)
     if handler !== nothing
-        try
-            param_type = get_param_type(handler.message_type)
-            params = param_type === Nothing ? nothing : param_type(msg["params"])
+        param_type = get_param_type(handler.message_type)
+        params = param_type === Nothing ? nothing : param_type(msg["params"])
 
-            res = handler.func(x, params)
+        res = handler.func(x, params)
 
-            if handler.message_type isa RequestType
-                send_success_response(x, msg, res)
-            end
-        catch err
-            if err isa JSONRPCError
-                send_error_response(x, msg, err.code, err.msg, err.data)
+        if handler.message_type isa RequestType
+            if res isa JSONRPCError
+                send_error_response(x, msg, res.code, res.msg, res.data)
             else
-                rethrow(err)
+                send_success_response(x, msg, res)
             end
         end
     else


### PR DESCRIPTION
This changes how we handle errors.

The new story is: if a handler function wants to return a JSON RPC error response, it should _not_ throw an error, but just return an instance of `JSONRPCError`.

That allows us to actually throw `JSONRPCError` if a request returns an error.

The current implementation hides error returns from the dreaded config requests, with this PR things should work better.