### PR TITLE
rename JSONRPCError field msg -> message

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1,6 +1,6 @@
 struct JSONRPCError <: Exception
     code::Int
-    msg::AbstractString
+    message::AbstractString
     data::Any
 end
 
@@ -33,7 +33,7 @@ function Base.showerror(io::IO, ex::JSONRPCError)
 
     print(io, error_code_as_string)
     print(io, ": ")
-    print(io, ex.msg)
+    print(io, ex.message)
     if ex.data !== nothing
         print(io, " (")
         print(io, ex.data)


### PR DESCRIPTION
`msg` was inconsistent with the JSONRPC spec and usage within the package (catch block of `dispatch_msg`).

Not clear if this requires downstream changes/version bump?