### PR TITLE
Improve error handling in @async

### DIFF
--- a/test/test_typed.jl
+++ b/test/test_typed.jl
@@ -1,9 +1,9 @@
 @testset "Message dispatcher" begin
 
     if Sys.iswindows()
-        global_socket_name = "\\\\.\\pipe\\jsonrpc-testrun"
+        global_socket_name1 = "\\\\.\\pipe\\jsonrpc-testrun1"
     elseif Sys.isunix()
-        global_socket_name = joinpath(tempdir(), "jsonrpc-testrun")
+        global_socket_name1 = joinpath(tempdir(), "jsonrpc-testrun1")
     else
         error("Unknown operating system.")
     end
@@ -17,7 +17,7 @@
     server_is_up = Base.Condition()
 
     server_task = @async try
-        server = listen(global_socket_name)
+        server = listen(global_socket_name1)
         notify(server_is_up)
         sock = accept(server)
         global conn = JSONRPC.JSONRPCEndpoint(sock, sock)
@@ -41,7 +41,7 @@
 
     wait(server_is_up)
 
-    sock2 = connect(global_socket_name)
+    sock2 = connect(global_socket_name1)
     conn2 = JSONRPCEndpoint(sock2, sock2)
 
     run(conn2)
@@ -63,10 +63,18 @@
 
     # Now we test a faulty server
 
+    if Sys.iswindows()
+        global_socket_name2 = "\\\\.\\pipe\\jsonrpc-testrun2"
+    elseif Sys.isunix()
+        global_socket_name2 = joinpath(tempdir(), "jsonrpc-testrun2")
+    else
+        error("Unknown operating system.")
+    end
+
     server_is_up = Base.Condition()
 
     server_task2 = @async try
-        server = listen(global_socket_name)
+        server = listen(global_socket_name2)
         notify(server_is_up)
         sock = accept(server)
         global conn = JSONRPC.JSONRPCEndpoint(sock, sock)
@@ -85,7 +93,7 @@
 
     wait(server_is_up)
 
-    sock2 = connect(global_socket_name)
+    sock2 = connect(global_socket_name2)
     conn2 = JSONRPCEndpoint(sock2, sock2)
 
     run(conn2)

--- a/test/test_typed.jl
+++ b/test/test_typed.jl
@@ -16,7 +16,7 @@
 
     server_is_up = Base.Condition()
 
-    server_task = @async begin
+    server_task = @async try
         server = listen(global_socket_name)
         notify(server_is_up)
         sock = accept(server)
@@ -35,6 +35,8 @@
         for msg in conn
             JSONRPC.dispatch_msg(conn, msg_dispatcher, msg)
         end
+    catch err
+        Base.display_error(stderr, err, catch_backtrace())
     end
 
     wait(server_is_up)
@@ -63,7 +65,7 @@
 
     server_is_up = Base.Condition()
 
-    server_task2 = @async begin
+    server_task2 = @async try
         server = listen(global_socket_name)
         notify(server_is_up)
         sock = accept(server)
@@ -77,6 +79,8 @@
         for msg in conn
             @test_throws ErrorException("The handler for the 'request2' request returned a value of type $Int, which is not a valid return type according to the request definition.") JSONRPC.dispatch_msg(conn, msg_dispatcher, msg)
         end
+    catch err
+        Base.display_error(stderr, err, catch_backtrace())
     end
 
     wait(server_is_up)


### PR DESCRIPTION
I think there is still some bug in the tests that prevent the first socket from being closed properly. BUT, for now this fixes the test failures.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
