### PR TITLE
Flush write stream after every msg

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -66,6 +66,7 @@ function write_transport_layer(stream, response)
     n = length(response_utf8)
     write(stream, "Content-Length: $n\r\n\r\n")
     write(stream, response_utf8)
+    flush(stream)
 end
 
 function read_transport_layer(stream)


### PR DESCRIPTION
I have no idea whether this will do any good, but I lately have the impression that e.g. the variable viewer in the debugger lags, and maybe this is one of the reasons? It seems like it can't hurt.