### PR TITLE
Don't crash on Ctrl-C

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -256,7 +256,13 @@ function Base.flush(endpoint::JSONRPCEndpoint)
     check_dead_endpoint!(endpoint)
 
     while isready(endpoint.out_msg_queue)
-        yield()
+        try
+            yield()
+        catch e
+            if !isa(e, InterruptException)
+                rethrow(e)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Displaying a large picture will often wait here for the queue to flush and an impatient Ctrl-C will crash the extension.
