### PR TITLE
Allow other applications to hook into `showerror`

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -36,21 +36,21 @@ const INVALID_REQUEST = -32600
 
 The method does not exist / is not available.
 """
-const METHOD_NOT_FOUND = -32700
+const METHOD_NOT_FOUND = -32601
 
 """
     INVALID_PARAMS
 
 Invalid method parameter(s).
 """
-const INVALID_PARAMS = -32700
+const INVALID_PARAMS = -32602
 
 """
     INTERNAL_ERROR
 
 Internal JSON-RPC error.
 """
-const INTERNAL_ERROR = -32700
+const INTERNAL_ERROR = -32603
 
 """
    RPCErrorStrings
@@ -67,6 +67,8 @@ const RPCErrorStrings = Base.IdDict(
     INTERNAL_ERROR => "InternalError",
     [ i => "ServerError" for i in -32099:-32000]...,
     # TODO: these should be removed - they are in the application/implementation specific range
+    -32000 => "serverErrorEnd",
+    -32099 => "serverErrorStart",
     -32002 => "ServerNotInitialized",
     -32001 => "UnknownErrorCode",
     -32800 => "RequestCancelled",

--- a/src/core.jl
+++ b/src/core.jl
@@ -52,6 +52,10 @@ Internal JSON-RPC error.
 """
 const INTERNAL_ERROR = -32603
 
+# these are the reserved endpoints of JSON-RPC error codes
+const SERVER_ERROR_END       = -32000
+const SERVER_ERROR_START     = -32099
+
 """
    RPCErrorStrings
 
@@ -65,7 +69,7 @@ const RPCErrorStrings = Base.IdDict(
     METHOD_NOT_FOUND => "MethodNotFound",
     INVALID_PARAMS => "InvalidParams",
     INTERNAL_ERROR => "InternalError",
-    [ i => "ServerError" for i in -32099:-32000]...,
+    [ i => "ServerError" for i in SERVER_ERROR_START:SERVER_ERROR_END]...,
     # TODO: these should be removed - they are in the application/implementation specific range
     -32000 => "serverErrorEnd",
     -32099 => "serverErrorStart",

--- a/src/core.jl
+++ b/src/core.jl
@@ -17,6 +17,28 @@ struct JSONRPCError <: Exception
 end
 
 """
+    SERVER_ERROR_END
+
+The end of the range of server-reserved errors.
+
+These are JSON-RPC server errors that are free for the taking
+for JSON-RPC server implementations. Applications making use of
+this library should NOT define new errors in this range.
+"""
+const SERVER_ERROR_END       = -32000
+
+"""
+    SERVER_ERROR_START
+
+The start of the range of server-reserved errors.
+
+These are JSON-RPC server errors that are free for the taking
+for JSON-RPC server implementations. Applications making use of
+this library should NOT define new errors in this range.
+"""
+const SERVER_ERROR_START     = -32099
+
+"""
     PARSE_ERROR
 
 Invalid JSON was received by the server.
@@ -52,10 +74,6 @@ Internal JSON-RPC error.
 """
 const INTERNAL_ERROR = -32603
 
-# these are the reserved endpoints of JSON-RPC error codes
-const SERVER_ERROR_END       = -32000
-const SERVER_ERROR_START     = -32099
-
 """
    RPCErrorStrings
 
@@ -70,13 +88,8 @@ const RPCErrorStrings = Base.IdDict(
     INVALID_PARAMS => "InvalidParams",
     INTERNAL_ERROR => "InternalError",
     [ i => "ServerError" for i in SERVER_ERROR_START:SERVER_ERROR_END]...,
-    # TODO: these should be removed - they are in the application/implementation specific range
-    -32000 => "serverErrorEnd",
-    -32099 => "serverErrorStart",
     -32002 => "ServerNotInitialized",
     -32001 => "UnknownErrorCode",
-    -32800 => "RequestCancelled",
-	-32801 => "ContentModified"
 )
 
 function Base.showerror(io::IO, ex::JSONRPCError)

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,35 +1,80 @@
+"""
+    JSONRPCError
+
+An object representing a JSON-RPC Error.
+
+Fields:
+ * code::Int
+ * msg::AbstractString
+ * data::Any
+
+See Section 5.1 of the JSON RPC 2.0 specification for more information.
+"""
 struct JSONRPCError <: Exception
     code::Int
     msg::AbstractString
     data::Any
 end
 
+"""
+    PARSE_ERROR
+
+Invalid JSON was received by the server.
+An error occurred on the server while parsing the JSON text.
+"""
+const PARSE_ERROR = -32700
+
+"""
+    INVALID_REQUEST
+
+The JSON sent is not a valid Request object.
+"""
+const INVALID_REQUEST = -32600
+
+"""
+    METHOD_NOT_FOUND
+
+The method does not exist / is not available.
+"""
+const METHOD_NOT_FOUND = -32700
+
+"""
+    INVALID_PARAMS
+
+Invalid method parameter(s).
+"""
+const INVALID_PARAMS = -32700
+
+"""
+    INTERNAL_ERROR
+
+Internal JSON-RPC error.
+"""
+const INTERNAL_ERROR = -32700
+
+"""
+   RPCErrorStrings
+
+A `Base.IdDict` containing the mapping of JSON-RPC error codes to a short, descriptive string.
+
+Use this to hook into `showerror(io::IO, ::JSONRPCError)` for display purposes. A default fallback to `"Unknown"` exists.
+"""
+const RPCErrorStrings = Base.IdDict(
+    PARSE_ERROR => "ParseError",
+    INVALID_REQUEST => "InvalidRequest",
+    METHOD_NOT_FOUND => "MethodNotFound",
+    INVALID_PARAMS => "InvalidParams",
+    INTERNAL_ERROR => "InternalError",
+    [ i => "ServerError" for i in -32099:-32000]...,
+    # TODO: these should be removed - they are in the application/implementation specific range
+    -32002 => "ServerNotInitialized",
+    -32001 => "UnknownErrorCode",
+    -32800 => "RequestCancelled",
+	-32801 => "ContentModified"
+)
+
 function Base.showerror(io::IO, ex::JSONRPCError)
-    error_code_as_string = if ex.code == -32700
-        "ParseError"
-    elseif ex.code == -32600
-        "InvalidRequest"
-    elseif ex.code == -32601
-        "MethodNotFound"
-    elseif ex.code == -32602
-        "InvalidParams"
-    elseif ex.code == -32603
-        "InternalError"
-    elseif ex.code == -32099
-        "serverErrorStart"
-    elseif ex.code == -32000
-        "serverErrorEnd"
-    elseif ex.code == -32002
-        "ServerNotInitialized"
-    elseif ex.code == -32001
-        "UnknownErrorCode"
-    elseif ex.code == -32800
-        "RequestCancelled"
-	elseif ex.code == -32801
-        "ContentModified"
-    else
-        "Unkonwn"
-    end
+    error_code_as_string = get(RPCErrorStrings, ex.code, "Unknown")
 
     print(io, error_code_as_string)
     print(io, ": ")

--- a/src/core.jl
+++ b/src/core.jl
@@ -25,7 +25,7 @@ These are JSON-RPC server errors that are free for the taking
 for JSON-RPC server implementations. Applications making use of
 this library should NOT define new errors in this range.
 """
-const SERVER_ERROR_END       = -32000
+const SERVER_ERROR_END = -32000
 
 """
     SERVER_ERROR_START
@@ -36,7 +36,7 @@ These are JSON-RPC server errors that are free for the taking
 for JSON-RPC server implementations. Applications making use of
 this library should NOT define new errors in this range.
 """
-const SERVER_ERROR_START     = -32099
+const SERVER_ERROR_START = -32099
 
 """
     PARSE_ERROR

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -4,11 +4,7 @@
     @test sprint(showerror, JSONRPC.JSONRPCError(-32601, "FOO", "BAR")) == "MethodNotFound: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(-32602, "FOO", "BAR")) == "InvalidParams: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(-32603, "FOO", "BAR")) == "InternalError: FOO (BAR)"
-    @test sprint(showerror, JSONRPC.JSONRPCError(-32099, "FOO", "BAR")) == "serverErrorStart: FOO (BAR)"
-    @test sprint(showerror, JSONRPC.JSONRPCError(-32000, "FOO", "BAR")) == "serverErrorEnd: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(-32002, "FOO", "BAR")) == "ServerNotInitialized: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(-32001, "FOO", "BAR")) == "UnknownErrorCode: FOO (BAR)"
-    @test sprint(showerror, JSONRPC.JSONRPCError(-32800, "FOO", "BAR")) == "RequestCancelled: FOO (BAR)"
-    @test sprint(showerror, JSONRPC.JSONRPCError(-32801, "FOO", "BAR")) == "ContentModified: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(1, "FOO", "BAR")) == "Unknown: FOO (BAR)"
 end

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -10,5 +10,5 @@
     @test sprint(showerror, JSONRPC.JSONRPCError(-32001, "FOO", "BAR")) == "UnknownErrorCode: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(-32800, "FOO", "BAR")) == "RequestCancelled: FOO (BAR)"
     @test sprint(showerror, JSONRPC.JSONRPCError(-32801, "FOO", "BAR")) == "ContentModified: FOO (BAR)"
-    @test sprint(showerror, JSONRPC.JSONRPCError(1, "FOO", "BAR")) == "Unkonwn: FOO (BAR)"
+    @test sprint(showerror, JSONRPC.JSONRPCError(1, "FOO", "BAR")) == "Unknown: FOO (BAR)"
 end


### PR DESCRIPTION
Closes #68.

This change allows other applications to customize `showerror(::IO, ::JSONRPCError)` depending on their specific needs and chosen meanings for their errors. It also introduces the fixed error codes as constants, to allow them to be transparently referenced in other places of the codebase.

Regarding `serverErrorStart` and `serverErrorEnd` - I don't know exactly how they're used in the VSCode extension/LS.jl (are the messages themselves matched anywhere?), so these could be added explicitly until those dependents are explicitly adding them to `RPCErrorStrings`. I've added them for now to make tests pass, but having them implicit seems cleaner to me.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
