### PR TITLE
Fix non-sending of error response on unsupported methods

### DIFF
--- a/src/typed.jl
+++ b/src/typed.jl
@@ -80,10 +80,10 @@ function dispatch_msg(x::JSONRPCEndpoint, dispatcher::MsgDispatcher, msg)
             end
         else
             if is_request # even invalid requests MUST get a response - see Section 5 of the JSON RPC specification.
-                send_error_response(x, msg, -32601, "Unknown method.", nothing)
+                send_error_response(x, msg, -32601, "Unknown method '$method_name'.", nothing)
             end
             # TODO: ignoring notifications is legal, so there's no need to crash here on unknown things. However, removing this requires downstream support.
-            error("Unknown method $method_name.")
+            error("Unknown method '$method_name'.")
         end
     finally
         dispatcher._currentlyHandlingMsg = false

--- a/src/typed.jl
+++ b/src/typed.jl
@@ -59,6 +59,7 @@ function dispatch_msg(x::JSONRPCEndpoint, dispatcher::MsgDispatcher, msg)
     dispatcher._currentlyHandlingMsg = true
     try
         method_name = msg["method"]
+        is_request = haskey(msg, "id")
         handler = get(dispatcher._handlers, method_name, nothing)
         if handler !== nothing
             param_type = get_param_type(handler.message_type)
@@ -78,6 +79,10 @@ function dispatch_msg(x::JSONRPCEndpoint, dispatcher::MsgDispatcher, msg)
                 end
             end
         else
+            if is_request # even invalid requests MUST get a response - see Section 5 of the JSON RPC specification.
+                send_error_response(x, msg, -32601, "Unknown method.", nothing)
+            end
+            # TODO: ignoring notifications is legal, so there's no need to crash here on unknown things. However, removing this requires downstream support.
             error("Unknown method $method_name.")
         end
     finally


### PR DESCRIPTION
According to the JSON-RPC spec, the server MUST reply to all RPC calls (except notifications) with a response, in particular when an error occurs (see Section 5 of the [JSON-RPC specification](https://www.jsonrpc.org/specification#response_object). JSONRPC.jl so far has not replied with error code `-32601` `Method not found` when a request was made that is not supported. This PR fixes that, by replying with that error code when encountering a request that is not supported.

Since notifications do not have responses (and should thus be ignorable?), the server from this PR only replies to method requests by checking whether an `id` field exists or not.

On top of this, I've also consolidated the test in that file a bit, to make testing easier. A temporary directory is now created per test-run, to make testing on a developer machine easier by not leaving artifacts of the previous run behind. I've also prevented deadlocks in the tests, which could happen if the `server_task` got to the `notify` call before the main call got to the `wait` in rare instances (that always seemed to happen on my machine as soon as I expanded the tests).

Since this change should be purely under the hood, I don't think any additional end-user documentation for the VS Code extension or a changelog mention should be required.

It would have been nice to refer to the error code as a constant, but that requires #70 and will thus be done at a later date.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
