### PR TITLE
Close outstanding request channels on error

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -145,6 +145,10 @@ function Base.run(x::JSONRPCEndpoint)
         finally
             close(x.in_msg_queue)
         end
+
+        for i in values(x.outstanding_requests)
+            close(i)
+        end
     catch err
         bt = catch_backtrace()
         if x.err_handler !== nothing


### PR DESCRIPTION
Previously a send request call would hang forever if the server process died.