### PR TITLE
Report a dead or stalled outbound half instead of failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version v3.0.2
+## Bug fixes
+- A write task that fails now marks the endpoint `status_errored`, as the read task already did. Previously only `err` was recorded, so a connection whose outbound half had died still reported `isopen(endpoint) == true`, callers that guard their sends on `isopen` kept writing into it, and the `TransportError` describing the failure was never raised — the next send surfaced a bare `InvalidStateException` from the queue the dying write task had closed.
+- `get_next_message` no longer leaks a cancellation registration onto each of its tokens per inbound message. It built a linked `CancellationTokenSource` per call, and a linked source's parent registrations are only released by closing them, which never happened — so closures accumulated for the life of the connection on lists that every later `readline`/`read`/`take!` on those tokens had to walk.
+
+## New features
+- `outbound_backlog(endpoint)` reports `(queued, blocked_seconds)` for the outbound half. The outbound queue is unbounded, so a peer that stops reading never makes a send fail; the messages just accumulate undelivered. The endpoint now also warns once when a single transport write has been outstanding for more than a minute.
+
 # Version v3.0.0
 ## Breaking changes
 - `run(endpoint)` renamed to `start(endpoint)` — now exported as `JSONRPC.start`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version v3.0.2
 ## Bug fixes
 - A write task that fails now marks the endpoint `status_errored`, as the read task already did. Previously only `err` was recorded, so a connection whose outbound half had died still reported `isopen(endpoint) == true`, callers that guard their sends on `isopen` kept writing into it, and the `TransportError` describing the failure was never raised — the next send surfaced a bare `InvalidStateException` from the queue the dying write task had closed.
+- The write task no longer records a transport error when a clean `close` drops the pipe under an in-flight write. It only special-cased `Base.IOError`, but Julia 1.0 raises `ArgumentError` from `check_open` for a write to a closed stream, so the error landed in the unguarded branch — and because `send_request` reports `endpoint.err` in preference to "Endpoint closed", a clean shutdown surfaced as a bogus transport failure. It now tests `isopen(pipe_out)` rather than the exception type, mirroring what the read task already did for `pipe_in`.
 - `get_next_message` no longer leaks a cancellation registration onto each of its tokens per inbound message. It built a linked `CancellationTokenSource` per call, and a linked source's parent registrations are only released by closing them, which never happened — so closures accumulated for the life of the connection on lists that every later `readline`/`read`/`take!` on those tokens had to walk.
 
 ## New features

--- a/src/core.jl
+++ b/src/core.jl
@@ -209,6 +209,14 @@ mutable struct JSONRPCEndpoint{IOIn<:IO,IOOut<:IO,S<:JSON.Serialization,F<:Frami
     serialization::S
 
     framing::F
+
+    # Observability for the outbound half. `write_started_at` is stamped before every
+    # transport write and cleared when it returns, so a peer that has stopped reading shows
+    # up as a long-outstanding write instead of as silence: the outbound queue is unbounded,
+    # so `send_notification` keeps succeeding and the messages simply pile up undelivered.
+    write_started_at::Union{Nothing,Float64}
+    write_stall_warned::Bool
+    write_monitor::Union{Nothing,Timer}
 end
 
 JSONRPCEndpoint(pipe_in, pipe_out, serialization::JSON.Serialization=JSON.StandardSerialization(); framing::FramingMode=ContentLengthFraming()) =
@@ -226,7 +234,10 @@ JSONRPCEndpoint(pipe_in, pipe_out, serialization::JSON.Serialization=JSON.Standa
         nothing,
         nothing,
         serialization,
-        framing)
+        framing,
+        nothing,
+        false,
+        nothing)
 
 write_transport_layer(stream, response, ::ContentLengthFraming) = write_transport_layer(stream, response)
 
@@ -349,6 +360,59 @@ end
 
 Base.isopen(x::JSONRPCEndpoint) = x.status == status_running && isopen(x.pipe_in) && isopen(x.pipe_out)
 
+# How often the monitor looks at the outbound half, and how long a single transport write
+# may be outstanding before it is worth a warning. Generous: a slow peer is normal, a peer
+# that has stopped reading altogether is not, and only the latter should be reported.
+const WRITE_STALL_CHECK_SECONDS = 15.0
+const WRITE_STALL_WARN_SECONDS = 60.0
+
+"""
+    outbound_backlog(x::JSONRPCEndpoint)
+
+How far behind the outbound half is: `(queued, blocked_seconds)`, where `queued` is the
+number of messages waiting to be written and `blocked_seconds` is how long the write
+currently in flight has been outstanding (`0.0` when none is).
+
+The outbound queue is unbounded, so a peer that stops reading its end never makes a send
+fail — the messages just accumulate, undelivered, with nothing to show for it. This is the
+one place that says so, and it stays meaningful after `close`.
+"""
+function outbound_backlog(x::JSONRPCEndpoint)
+    queued = try
+        Base.n_avail(x.out_msg_queue)
+    catch
+        # `n_avail` is internal; fall back to the buffer itself before giving up, so a
+        # future Julia that renames it degrades to a still-useful number rather than to 0.
+        try
+            length(x.out_msg_queue.data)
+        catch
+            0
+        end
+    end
+    started = x.write_started_at
+    return (queued=queued, blocked_seconds=started === nothing ? 0.0 : time() - started)
+end
+
+# A blocked write task cannot report itself — it is inside the write. Hence a timer, which
+# only ever warns once per stall and resets when writes start completing again.
+function _start_write_monitor(x::JSONRPCEndpoint)
+    return Timer(WRITE_STALL_CHECK_SECONDS; interval=WRITE_STALL_CHECK_SECONDS) do t
+        try
+            started = x.write_started_at
+            if started === nothing
+                x.write_stall_warned = false
+            elseif !x.write_stall_warned && time() - started >= WRITE_STALL_WARN_SECONDS
+                x.write_stall_warned = true
+                backlog = outbound_backlog(x)
+                @warn "JSON-RPC endpoint has been blocked writing to its peer; outgoing messages are queueing up and will not be delivered until the peer resumes reading" blocked_seconds = round(backlog.blocked_seconds, digits=1) queued_messages = backlog.queued
+            end
+        catch
+            # A monitor that throws would silently kill its own timer, and it is only ever
+            # advisory. Nothing here is worth taking down.
+        end
+    end
+end
+
 function start(x::JSONRPCEndpoint)
     x.status == status_idle || error("Endpoint is not idle.")
 
@@ -359,20 +423,36 @@ function start(x::JSONRPCEndpoint)
     x.write_task = @async try
         try
             for msg in x.out_msg_queue
-                write_transport_layer(x.pipe_out, msg, x.framing)
+                x.write_started_at = time()
+                try
+                    write_transport_layer(x.pipe_out, msg, x.framing)
+                finally
+                    x.write_started_at = nothing
+                end
             end
         finally
             close(x.out_msg_queue)
         end
     catch err
+        # `status` matters as much as `err` here. The read task sets `status_errored` on
+        # every failure path, but this one used to record `err` and leave the status alone —
+        # so a dead outbound half still reported `isopen(endpoint) == true`, callers that
+        # guard sends on `isopen` kept writing into it, and `check_dead_endpoint!` never
+        # raised the `TransportError` that says what actually went wrong. The next `put!`
+        # then hit the queue closed by the `finally` above and surfaced a bare
+        # `InvalidStateException` instead.
         if err isa Base.IOError
             if !CancellationTokens.is_cancellation_requested(endpoint_token)
                 x.err === nothing && (x.err = TransportError("Write task IOError", err))
+                x.status = status_errored
             end
         else
             x.err === nothing && (x.err = TransportError("Write task failed", err))
+            x.status = status_errored
         end
     end
+
+    x.write_monitor = _start_write_monitor(x)
 
     x.read_task = @async try
         try
@@ -611,12 +691,28 @@ function get_next_message(endpoint::JSONRPCEndpoint; token::Union{Nothing,Cancel
     check_dead_endpoint!(endpoint)
 
     endpoint_token = CancellationTokens.get_token(endpoint.endpoint_cancellation_source)
-    wait_token = if token !== nothing
-        combined_source = CancellationTokens.CancellationTokenSource(token, endpoint_token)
-        CancellationTokens.get_token(combined_source)
-    else
-        endpoint_token
+
+    # Linked by hand rather than via `CancellationTokenSource(token, endpoint_token)`,
+    # because that constructor discards the registrations it makes on its parents, and a
+    # linked source's parent registrations are only ever dropped by closing them. One of
+    # these is built per inbound message, so the convenience constructor leaked two entries
+    # onto the caller's token and the endpoint token for every message the endpoint ever
+    # received: closures held alive for the life of the connection, on lists that
+    # `close(::CancellationTokenRegistration)` walks linearly, so every later
+    # `readline`/`read`/`take!` on those tokens paid for all of them. Keeping the
+    # registrations is what lets the `finally` below give them back.
+    combined_source = token === nothing ? nothing : CancellationTokens.CancellationTokenSource()
+    parent_registrations = CancellationTokens.CancellationTokenRegistration[]
+    if combined_source !== nothing
+        for parent in (token, endpoint_token)
+            push!(parent_registrations, CancellationTokens.register(parent) do
+                CancellationTokens.cancel(combined_source)
+            end)
+        end
     end
+
+    wait_token = combined_source === nothing ? endpoint_token : CancellationTokens.get_token(combined_source)
+
     try
         msg = take!(endpoint.in_msg_queue, wait_token)
         return msg
@@ -629,6 +725,10 @@ function get_next_message(endpoint::JSONRPCEndpoint; token::Union{Nothing,Cancel
             throw(TransportError("Endpoint closed", nothing))
         else
             rethrow(err)
+        end
+    finally
+        for reg in parent_registrations
+            close(reg)
         end
     end
 end
@@ -679,6 +779,13 @@ end
 
 function Base.close(endpoint::JSONRPCEndpoint)
     endpoint.status == status_closed && return
+
+    # First, so that a write task wedged against an unresponsive peer — which the `fetch`
+    # below then waits on — cannot keep the timer alive after the endpoint is gone.
+    if endpoint.write_monitor !== nothing
+        try close(endpoint.write_monitor) catch end
+        endpoint.write_monitor = nothing
+    end
 
     # Signal the read task to stop — this unblocks any cancellation-aware reads
     # (TCPSocket/PipeEndpoint). For non-cancellation-aware streams, the caller

--- a/src/core.jl
+++ b/src/core.jl
@@ -446,6 +446,18 @@ function start(x::JSONRPCEndpoint)
                 x.err === nothing && (x.err = TransportError("Write task IOError", err))
                 x.status = status_errored
             end
+        elseif !isopen(x.pipe_out)
+            # The pipe is gone, so this is a write to a broken pipe however it presented.
+            # Julia versions and platforms disagree about the type: 1.0 raises
+            # `ArgumentError` from `check_open` where later ones raise `IOError`. Test the
+            # pipe rather than the exception, exactly as the read task does for `pipe_in`.
+            # Without this, a clean `close()` landing while a write is still in flight
+            # records a transport error that never happened, and `send_request` reports it
+            # in place of "Endpoint closed".
+            if !CancellationTokens.is_cancellation_requested(endpoint_token)
+                x.err === nothing && (x.err = TransportError("Write task IOError", err))
+                x.status = status_errored
+            end
         else
             x.err === nothing && (x.err = TransportError("Write task failed", err))
             x.status = status_errored

--- a/test/test_coverage_gaps.jl
+++ b/test/test_coverage_gaps.jl
@@ -378,11 +378,17 @@ end
     sleep(0.5)
 
     @test istaskdone(ep.write_task)
-    # Endpoint still running (read task waiting on socket1)
-    @test ep.status == JSONRPC.status_running
+    # A write task that died takes the endpoint's status with it, so a caller cannot keep
+    # sending into a connection that can no longer deliver.
+    @test ep.status == JSONRPC.status_errored
+    @test_throws JSONRPC.TransportError flush(ep)
 
-    # flush: while isready → istaskdone → break
+    # flush: while isready → istaskdone → break. Only reachable when the write task dies
+    # *during* a flush, which is inherently racy to stage; the status is put back by hand to
+    # reach the branch deterministically.
+    ep.status = JSONRPC.status_running
     flush(ep)
+    ep.status = JSONRPC.status_errored
 
     close(socket1)
     close(ep)

--- a/test/test_write_half.jl
+++ b/test/test_write_half.jl
@@ -116,3 +116,34 @@ end
         close(endpoint)
     end
 end
+
+@testitem "A clean close does not record a write error" begin
+    using CancellationTokens
+
+    # `close(endpoint)` cancels the endpoint token and drops the pipe, and that can land
+    # while a write is still in flight. It must not leave a `TransportError` behind:
+    # `send_request` reports `endpoint.err` in preference to "Endpoint closed", so a
+    # spurious one turns a clean shutdown into a bogus transport failure.
+    #
+    # A closed `IOBuffer` raises `ArgumentError` on write, which is the shape Julia 1.0
+    # produces for a closed stream (later versions raise `IOError` there). That is how this
+    # slipped past a guard that only looked for `IOError`, and using an `IOBuffer` here
+    # reproduces it on every version rather than only on the one that surfaced it.
+    pipe_in = Base.BufferStream()
+    pipe_out = IOBuffer()
+    close(pipe_out)
+
+    endpoint = JSONRPC.JSONRPCEndpoint(pipe_in, pipe_out)
+    JSONRPC.start(endpoint)
+
+    # Stand in for a `close(endpoint)` already under way.
+    CancellationTokens.cancel(endpoint.endpoint_cancellation_source)
+
+    JSONRPC.send_notification(endpoint, "somemethod", nothing)
+    wait(endpoint.write_task)
+
+    @test endpoint.err === nothing
+
+    close(pipe_in)
+    close(endpoint)
+end

--- a/test/test_write_half.jl
+++ b/test/test_write_half.jl
@@ -1,0 +1,118 @@
+@testitem "A dead write task marks the endpoint errored" begin
+    # The write half can die on its own — the read half never learns about it. Before this
+    # was fixed the endpoint went on reporting `status_running`, so callers that guard their
+    # sends on `isopen` kept writing into a connection that could no longer deliver, and the
+    # `TransportError` describing the real failure was never raised.
+    pipe_in = Base.BufferStream()
+    pipe_out = IOBuffer()
+    close(pipe_out)  # every write from now on throws
+
+    endpoint = JSONRPC.JSONRPCEndpoint(pipe_in, pipe_out)
+    JSONRPC.start(endpoint)
+    @test endpoint.status == JSONRPC.status_running
+
+    JSONRPC.send_notification(endpoint, "somemethod", nothing)
+    wait(endpoint.write_task)  # the task catches, so this returns rather than throwing
+
+    @test endpoint.status == JSONRPC.status_errored
+    @test !isopen(endpoint)
+    @test endpoint.err isa JSONRPC.TransportError
+
+    # And the next send reports *that*, rather than the `InvalidStateException` from the
+    # queue the dying write task closed behind it.
+    err = try
+        JSONRPC.send_notification(endpoint, "somemethod", nothing)
+        nothing
+    catch ex
+        ex
+    end
+    @test err isa JSONRPC.TransportError
+
+    close(pipe_in)
+    close(endpoint)
+end
+
+@testitem "outbound_backlog reports undelivered messages" begin
+    # The outbound queue is unbounded, so a peer that stops reading never makes a send fail.
+    # This is the only signal that anything is wrong.
+    endpoint = JSONRPC.JSONRPCEndpoint(Base.BufferStream(), Base.BufferStream())
+
+    backlog = JSONRPC.outbound_backlog(endpoint)
+    @test backlog.queued == 0
+    @test backlog.blocked_seconds == 0.0
+
+    # Not started, so nothing drains the queue — the same shape a blocked write task leaves.
+    put!(endpoint.out_msg_queue, "one")
+    put!(endpoint.out_msg_queue, "two")
+
+    backlog = JSONRPC.outbound_backlog(endpoint)
+    @test backlog.queued == 2
+    @test backlog.blocked_seconds == 0.0
+end
+
+@testitem "get_next_message does not leak registrations onto its tokens" begin
+    using CancellationTokens
+
+    caller_source = CancellationTokens.CancellationTokenSource()
+    caller_token = CancellationTokens.get_token(caller_source)
+
+    endpoint = JSONRPC.JSONRPCEndpoint(Base.BufferStream(), Base.BufferStream())
+    JSONRPC.start(endpoint)
+
+    # Reaching into CancellationTokens to count registrations is the only way to observe
+    # this; skip rather than fail if the field is ever renamed.
+    if isdefined(caller_source, :_callbacks)
+        baseline_caller = length(caller_source._callbacks)
+        baseline_endpoint = length(endpoint.endpoint_cancellation_source._callbacks)
+
+        for i in 1:50
+            put!(endpoint.in_msg_queue, JSONRPC.Request("somemethod", nothing, nothing, nothing))
+            msg = JSONRPC.get_next_message(endpoint, token=caller_token)
+            @test msg.method == "somemethod"
+        end
+
+        # One linked source per message used to leave a callback on each parent behind.
+        @test length(caller_source._callbacks) == baseline_caller
+        @test length(endpoint.endpoint_cancellation_source._callbacks) == baseline_endpoint
+    end
+
+    close(endpoint.pipe_in)
+    close(endpoint)
+end
+
+@testitem "get_next_message still honours both of its tokens" begin
+    using CancellationTokens
+
+    # The hand-rolled linking has to behave exactly like the combined source it replaced.
+    for cancel_the_caller in (true, false)
+        caller_source = CancellationTokens.CancellationTokenSource()
+        caller_token = CancellationTokens.get_token(caller_source)
+
+        endpoint = JSONRPC.JSONRPCEndpoint(Base.BufferStream(), Base.BufferStream())
+        JSONRPC.start(endpoint)
+
+        waiter = @async try
+            JSONRPC.get_next_message(endpoint, token=caller_token)
+            nothing
+        catch err
+            err
+        end
+
+        sleep(0.2)
+        if cancel_the_caller
+            CancellationTokens.cancel(caller_source)
+        else
+            CancellationTokens.cancel(endpoint.endpoint_cancellation_source)
+        end
+
+        err = fetch(waiter)
+        if cancel_the_caller
+            @test err isa CancellationTokens.OperationCanceledException
+        else
+            @test err isa JSONRPC.TransportError
+        end
+
+        close(endpoint.pipe_in)
+        close(endpoint)
+    end
+end


### PR DESCRIPTION
## Why

[This CI run](https://github.com/JuliaControl/ModelPredictiveControl.jl/actions/runs/32420160289/attempts/1) failed with a test item reported as a one-hour timeout that had actually **passed 17/17 in 9.8 seconds**:

```
99 tests ran, 98 passed, 1 errored.
  [ERROR] Luenb. estimator methods
    Test Summary:                                   | Pass  Total  Time
    …:Luenb. estimator methods                      |   17     17  9.8s
    Test item 'Luenb. estimator methods' timed out after 3600.0 seconds
```

Reconstructed from the run's artifacts, one of the three test processes went silent on its JSON-RPC socket at 22:48:14 and stayed silent until it was killed at 23:48:24. Over that hour it was demonstrably healthy: its **stdout kept flowing** to the controller (both test summaries are in the captured process output), it disarmed its own hang watchdog normally — meaning `run_testitem` returned and reached the `JSONRPC.send` on the very next line — and it went on to run and pass the *next* test item. The other two processes reported normally throughout.

Reading the controller end to end rules out a skipped send, a blocked queue (all are unbounded) and a dead read/dispatch task (those throw and are logged). What is left is a stall or a silent death inside the transport — and the transport had no way to report either. Neither side logged a thing.

## What this changes

**A failed write task now marks the endpoint errored.** The read task sets `status_errored` on every failure path; the write task recorded `err` and left `status` alone. So a connection whose outbound half had died still reported `isopen(endpoint) == true` — and `TestItemControllers` guards `_send_run_testitems!`, `_activate_env!`, `_configure_testrun!` and `_send_steal!` with exactly that check, so it kept writing into it. `check_dead_endpoint!` never raised the recorded `TransportError`, and the next `put!` hit the queue closed by the write task's own `finally`, surfacing a bare `InvalidStateException` that hides the real cause.

**A blocked write is now observable.** `write_transport_layer` writes straight to the socket; if the peer stops draining, the write task blocks *inside* the write and stays alive. Because the outbound queue is `Channel{Any}(Inf)`, `send_notification` keeps returning successfully and the messages pile up in memory forever — a completely silent one-directional stall, which is the case that best fits the evidence above. New `outbound_backlog(endpoint)` returns `(queued, blocked_seconds)`, and a monitor warns once when a single write has been outstanding beyond a minute. A one-hour block previously produced zero log lines.

**`get_next_message` no longer leaks a registration per inbound message.** It built `CancellationTokenSource(token, endpoint_token)` per call. That constructor *discards* the registrations it makes on its parents, and a linked source's parent registrations are only released by closing them — so `close`-ing the combined source would not have helped. Every message therefore left two closures behind for the life of the connection, on lists that `close(::CancellationTokenRegistration)` walks linearly, so every later `readline`/`read`/`take!` on those tokens paid for all of them. Bounded and small over a CI run; unbounded over a VS Code session. The linking is now done by hand so the registrations can be given back.

## Notes

- One existing test in `test_coverage_gaps.jl` asserted the old behaviour (`status_running` after the write task died). It now asserts the fix, and reaches `flush`'s `istaskdone` branch deterministically — that branch is now only naturally reachable when the write task dies *during* a flush.
- Related, not fixed here: `CancellationTokens`' own `Base.sleep(sec, token)` has the same leak shape — it builds a combined source, cancels only `timer_src`, and leaves the combined source registered on `token`. Worth an upstream issue.
- Deliberately out of scope: making `TestItemControllers` *recover* from a lost result — re-running the item on a healthy worker rather than failing it — which is what would have turned that run green. That needs a second source of truth about worker progress and is a separate design question. A companion PR on `TestItemControllers` adds the diagnostics that would name the mechanism if it recurs.

## Testing

`Pkg.test()` green: 561/561 (baseline on `main` is 497/497). New `test/test_write_half.jl` covers the errored-status transition and the `TransportError`-not-`InvalidStateException` behaviour, `outbound_backlog`, the registration counts before and after 50 `get_next_message` calls, and that the hand-rolled token linking still honours both the caller token and the endpoint token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
