### PR TITLE
Fix the same cancellation-registration leak in send_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version v3.0.3
+## Bug fixes
+- `send_request` no longer leaks a cancellation registration onto each of its tokens per request. It is the same defect fixed in `get_next_message` in v3.0.2, in the second of the two places it occurred: a linked `CancellationTokenSource` built per call, whose parent registrations are only released by closing them. Only reachable when a `client_token` is passed, so it leaked per request rather than per inbound message.
+
 # Version v3.0.2
 ## Bug fixes
 - A write task that fails now marks the endpoint `status_errored`, as the read task already did. Previously only `err` was recorded, so a connection whose outbound half had died still reported `isopen(endpoint) == true`, callers that guard their sends on `isopen` kept writing into it, and the `TransportError` describing the failure was never raised — the next send surfaced a bare `InvalidStateException` from the queue the dying write task had closed.

--- a/src/core.jl
+++ b/src/core.jl
@@ -641,14 +641,26 @@ function send_request(x::JSONRPCEndpoint, method::AbstractString, @nospecialize(
         end
     end
 
-    # Build the token used for local waiting: combines endpoint token + optional client token
+    # Build the token used for local waiting: combines endpoint token + optional client token.
+    # Linked by hand for the same reason as in `get_next_message`:
+    # `CancellationTokenSource(client_token, endpoint_token)` discards the registrations it makes
+    # on its parents, and a linked source's parent registrations are only released by closing
+    # them — so `close`-ing the combined source would not help. Without keeping them, every
+    # request carrying a `client_token` left two closures behind on that token and on the
+    # endpoint token for the life of the connection, on lists that
+    # `close(::CancellationTokenRegistration)` walks linearly.
     endpoint_token = CancellationTokens.get_token(x.endpoint_cancellation_source)
-    wait_token = if client_token !== nothing
-        combined_source = CancellationTokens.CancellationTokenSource(client_token, endpoint_token)
-        CancellationTokens.get_token(combined_source)
-    else
-        endpoint_token
+    combined_source = client_token === nothing ? nothing : CancellationTokens.CancellationTokenSource()
+    parent_registrations = CancellationTokens.CancellationTokenRegistration[]
+    if combined_source !== nothing
+        for parent in (client_token, endpoint_token)
+            push!(parent_registrations, CancellationTokens.register(parent) do
+                CancellationTokens.cancel(combined_source)
+            end)
+        end
     end
+
+    wait_token = combined_source === nothing ? endpoint_token : CancellationTokens.get_token(combined_source)
 
     cancelled_by_client = false
     try
@@ -695,6 +707,9 @@ function send_request(x::JSONRPCEndpoint, method::AbstractString, @nospecialize(
         end
         if server_cancel_registration !== nothing
             close(server_cancel_registration)
+        end
+        for reg in parent_registrations
+            close(reg)
         end
     end
 end

--- a/test/test_write_half.jl
+++ b/test/test_write_half.jl
@@ -147,3 +147,56 @@ end
     close(pipe_in)
     close(endpoint)
 end
+
+
+@testitem "send_request does not leak registrations onto its tokens" setup=[NamedPipes] begin
+    using CancellationTokens
+
+    # Same defect as the `get_next_message` one below/above: a linked source built per call,
+    # whose parent registrations are never given back. Only reachable when a `client_token` is
+    # passed, so it leaks per request rather than per inbound message — but it is the same bug.
+    socket1, socket2 = NamedPipes.get_named_pipe()
+
+    request_type = JSONRPC.RequestType("echo", Nothing, String)
+
+    server = JSONRPC.JSONRPCEndpoint(socket1, socket1)
+    client = JSONRPC.JSONRPCEndpoint(socket2, socket2)
+
+    msg_dispatcher = JSONRPC.MsgDispatcher()
+    msg_dispatcher[request_type] = (conn, params, token) -> "hello"
+
+    JSONRPC.start(server)
+    JSONRPC.start(client)
+
+    server_task = @async try
+        for msg in server
+            JSONRPC.dispatch_msg(server, msg_dispatcher, msg)
+        end
+    catch
+    end
+
+    client_source = CancellationTokens.CancellationTokenSource()
+    client_token = CancellationTokens.get_token(client_source)
+
+    # Reaching into CancellationTokens to count registrations is the only way to observe this;
+    # skip rather than fail if the field is ever renamed.
+    if isdefined(client_source, :_callbacks)
+        # One warm-up request first, so any one-off registrations are already in the baseline.
+        @test JSONRPC.send(client, request_type, nothing; client_token=client_token) == "hello"
+
+        baseline_client = length(client_source._callbacks)
+        baseline_endpoint = length(client.endpoint_cancellation_source._callbacks)
+
+        for i in 1:20
+            @test JSONRPC.send(client, request_type, nothing; client_token=client_token) == "hello"
+        end
+
+        @test length(client_source._callbacks) == baseline_client
+        @test length(client.endpoint_cancellation_source._callbacks) == baseline_endpoint
+    end
+
+    close(client)
+    close(socket2)
+    close(server)
+    close(socket1)
+end


### PR DESCRIPTION
## Why

[#111](https://github.com/julia-vscode/JSONRPC.jl/pull/111) fixed this leak in `get_next_message` and **missed the second place it occurs**. I found it while checking that the fixes had actually reached the vendored copies downstream.

`send_request` builds a linked source per call:

```julia
wait_token = if client_token !== nothing
    combined_source = CancellationTokens.CancellationTokenSource(client_token, endpoint_token)
    CancellationTokens.get_token(combined_source)
```

and its `finally` never disposes it. Disposing it would not have helped either — `CancellationTokenSource(tokens...)` *discards* the registrations it makes on its parents, so a linked source's parent registrations can only be released by holding and closing them. That is why the fix here is hand-linking rather than an added `close`.

The effect is the same as the original: two closures left behind per call — one on the client token, one on the endpoint token — alive for the whole connection, on lists that `close(::CancellationTokenRegistration)` walks linearly, so every later `readline`/`read`/`take!` on those tokens pays for all of them.

## Reach

Narrower than the `get_next_message` one, which fired on every inbound message. Here the source is only built when a `client_token` is actually passed, and among the consumers only **JuliaWorkspaces** ever passes one (3 call sites). TestItemControllers, LanguageServer and JuliaMCP never do, so this is not reachable from the testitem stack.

## Testing

`Pkg.test()` green at 585/585. The new test counts registrations on both parent sources across 20 requests with a `client_token`; verified it fails without the fix (`583 passed, 2 failed`, both parents growing) and passes with it.

Not urgent enough to tag for on its own — worth folding into whenever JSONRPC is next tagged, after which the vendored copies in TestItemControllers and JuliaWorkspaces pick it up on their next re-vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
