### PR TITLE
Release the write monitor when the peer disconnects first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version v3.0.3
+## Bug fixes
+- `close(endpoint)` now releases the write-stall monitor timer, the outbound queue and the write task even when the peer disconnected first. It guarded its own idempotency on `status == status_closed`, but that status is also set by the read task's `finally` on a clean EOF, so `close` returned early on exactly the path where the peer had gone away — leaking a repeating `Timer` (a live libuv handle) plus a blocked write task per endpoint. Among other things this made precompilation hang for packages that exercise an endpoint pair in a `@compile_workload` ("waiting for IO to finish: timer ..."). `close` now tracks that it has run in a dedicated field.
+
 # Version v3.0.2
 ## Bug fixes
 - A write task that fails now marks the endpoint `status_errored`, as the read task already did. Previously only `err` was recorded, so a connection whose outbound half had died still reported `isopen(endpoint) == true`, callers that guard their sends on `isopen` kept writing into it, and the `TransportError` describing the failure was never raised — the next send surfaced a bare `InvalidStateException` from the queue the dying write task had closed.

--- a/src/core.jl
+++ b/src/core.jl
@@ -217,6 +217,12 @@ mutable struct JSONRPCEndpoint{IOIn<:IO,IOOut<:IO,S<:JSON.Serialization,F<:Frami
     write_started_at::Union{Nothing,Float64}
     write_stall_warned::Bool
     write_monitor::Union{Nothing,Timer}
+    # `close` is idempotent, but it cannot decide that from `status`: the read task's
+    # `finally` sets `status_closed` on its own whenever the peer disconnects first.
+    # Guarding on the status made `close` return before it released the write monitor,
+    # the outbound queue and the write task — one leaked uv timer handle and one leaked
+    # task per endpoint whose peer went away first.
+    close_started::Bool
 end
 
 JSONRPCEndpoint(pipe_in, pipe_out, serialization::JSON.Serialization=JSON.StandardSerialization(); framing::FramingMode=ContentLengthFraming()) =
@@ -237,7 +243,8 @@ JSONRPCEndpoint(pipe_in, pipe_out, serialization::JSON.Serialization=JSON.Standa
         framing,
         nothing,
         false,
-        nothing)
+        nothing,
+        false)
 
 write_transport_layer(stream, response, ::ContentLengthFraming) = write_transport_layer(stream, response)
 
@@ -790,7 +797,8 @@ function send_error_response(endpoint, original_request::Request, @nospecialize(
 end
 
 function Base.close(endpoint::JSONRPCEndpoint)
-    endpoint.status == status_closed && return
+    endpoint.close_started && return
+    endpoint.close_started = true
 
     # First, so that a write task wedged against an unresponsive peer — which the `fetch`
     # below then waits on — cannot keep the timer alive after the endpoint is gone.

--- a/test/test_write_half.jl
+++ b/test/test_write_half.jl
@@ -147,3 +147,36 @@ end
     close(pipe_in)
     close(endpoint)
 end
+
+@testitem "close releases the write monitor after a peer-initiated EOF" begin
+    # The write monitor is a *repeating* timer, and `close(endpoint)` is its only owner —
+    # nothing else ever releases it. `close` used to return early on
+    # `status == status_closed`, but that status is not its own: the read task's `finally`
+    # sets it whenever the peer disconnects first. So an endpoint whose peer went away
+    # before it was closed leaked the timer (a live uv handle), its outbound queue and its
+    # write task — enough to make precompilation of a package that exercises an endpoint
+    # pair in its workload fail with "waiting for IO to finish: timer ...".
+    pipe_in = Base.BufferStream()
+    pipe_out = Base.BufferStream()
+
+    endpoint = JSONRPC.JSONRPCEndpoint(pipe_in, pipe_out)
+    JSONRPC.start(endpoint)
+    @test endpoint.write_monitor isa Timer
+
+    # The peer drops the connection. A clean EOF, so the read task records no error.
+    close(pipe_in)
+    wait(endpoint.read_task)
+    @test endpoint.err === nothing
+    @test endpoint.status == JSONRPC.status_closed  # set by the read task, not by `close`
+
+    close(endpoint)
+    @test endpoint.write_monitor === nothing
+    @test !isopen(endpoint.out_msg_queue)
+    @test istaskdone(endpoint.write_task)
+    @test endpoint.status == JSONRPC.status_closed
+
+    close(endpoint)  # still idempotent
+    @test endpoint.write_monitor === nothing
+
+    close(pipe_out)
+end


### PR DESCRIPTION
## The bug

`JSONRPC.start(endpoint)` arms a **repeating** write-stall watchdog `Timer`, and `Base.close(::JSONRPCEndpoint)` is its only owner. But `close` guarded its own idempotency on a status it does not own:

```julia
function Base.close(endpoint::JSONRPCEndpoint)
    endpoint.status == status_closed && return   # core.jl:793
    if endpoint.write_monitor !== nothing        # never reached on that path
```

`status_closed` is also set by the read task's `finally` on a clean EOF (`core.jl:578`). So whenever the peer disconnected first, `close` returned at the guard and skipped everything below it:

- the write-stall monitor `Timer` — a live libuv handle, never released
- `close(out_msg_queue)`
- `fetch(write_task)` — the write task stays blocked on the queue

That is a steady leak of one timer handle and one task per endpoint whose peer went away first — which is the *normal* case for a supervisor whose child processes exit.

It also breaks precompilation of any package that exercises an endpoint pair in a `@compile_workload`. Two `start` calls leave two open timers, and Julia refuses to write the `.ji`:

```
[pid 21172] waiting for IO to finish:
 Handle type        uv_handle_t->data
 timer              00000220ab236130->00000220a6e0de10
 timer              00000220ab2364b0->00000220a6e0de50
```

That is how this surfaced: `TestItemControllers` re-precompiled and re-failed on every VS Code test-controller start.

## The fix

`close` now records that it has run in a dedicated `close_started::Bool` field, so it stays idempotent without borrowing a status the read task also writes. The rest of the body is unchanged and was already re-entrant-safe (`!== nothing` / `isopen(...) &&` / `try ... catch` on every step).

Endpoints left in `status_idle` (constructed but never started) now run the full body — harmless, since every field it touches is `nothing` or an open-but-empty channel.

The new field is positional on the inner constructor only; every call site in `src/` and `test/` goes through the outer constructor, which is updated.

## Verification

New testitem in `test/test_write_half.jl`, driving the endpoint to a clean peer-initiated EOF before calling `close`. Without the fix it fails 4/8:

```
Expression: endpoint.write_monitor === nothing
 Evaluated: Timer (open, timeout: 15.0 s, interval: 15.0 s) === nothing
Expression: !(isopen(endpoint.out_msg_queue))
Expression: istaskdone(endpoint.write_task)
```

With the fix, 8/8. The rest of the suite is unaffected (`test/` passes 570/570).

Measured against a standalone reproduction of the reporting package's workload, counting leaked timers for both close orders:

| | sockets closed first | endpoints closed first |
|---|---|---|
| before | **2 leak** | **1 leaks** |
| after | 0 | 0 |

(Closing endpoints first is not a workaround: `close(client)` drives the *server's* read task to EOF, so `close(server)` then hits the same early return.)

End to end, with this vendored into `TestItemControllers`: precompiles cleanly in ~10s with no "waiting for IO to finish", and a second run is a cached no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
