### PR TITLE
Deliver what a disconnected endpoint already read before reporting it closed

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -721,7 +721,36 @@ function send_request(x::JSONRPCEndpoint, method::AbstractString, @nospecialize(
     end
 end
 
+"""
+Hand back a message the endpoint has already read off the wire, or `nothing` when it holds
+none.
+
+`in_msg_queue` is unbounded, so the read task runs as far ahead of whoever consumes the
+endpoint as the transport allows. When the peer disconnects, that task's `finally` cancels
+`endpoint_cancellation_source` and closes the queue in one go — and every message still
+sitting in it became unreachable, because both `check_dead_endpoint!` and the cancelled wait
+token report the endpoint dead without ever looking at what it is still holding. A peer that
+reports a result and then exits had that result thrown away, and the caller saw only the
+disconnect.
+"""
+function _take_buffered_message(endpoint::JSONRPCEndpoint)
+    isready(endpoint.in_msg_queue) || return nothing
+    return try
+        take!(endpoint.in_msg_queue)
+    catch err
+        # Raced with the channel closing empty; there is nothing buffered after all.
+        err isa InvalidStateException ? nothing : rethrow(err)
+    end
+end
+
 function get_next_message(endpoint::JSONRPCEndpoint; token::Union{Nothing,CancellationTokens.CancellationToken}=nothing)
+    # Only on the way down: while the endpoint is running the ordinary blocking path below
+    # is what feeds the queue's consumer, and short-circuiting it here would change nothing
+    # except the fast path's cost.
+    if endpoint.status !== status_running
+        buffered = _take_buffered_message(endpoint)
+        buffered === nothing || return buffered
+    end
     check_dead_endpoint!(endpoint)
 
     endpoint_token = CancellationTokens.get_token(endpoint.endpoint_cancellation_source)
@@ -755,6 +784,10 @@ function get_next_message(endpoint::JSONRPCEndpoint; token::Union{Nothing,Cancel
             if token !== nothing && CancellationTokens.is_cancellation_requested(token) && !CancellationTokens.is_cancellation_requested(endpoint_token)
                 throw(CancellationTokens.OperationCanceledException(token))
             end
+            # The read task's teardown can land between the drain above and this `take!`,
+            # so what it left behind is only visible from here.
+            buffered = _take_buffered_message(endpoint)
+            buffered === nothing || return buffered
             endpoint.err !== nothing && throw(endpoint.err)
             throw(TransportError("Endpoint closed", nothing))
         else
@@ -768,6 +801,13 @@ function get_next_message(endpoint::JSONRPCEndpoint; token::Union{Nothing,Cancel
 end
 
 function Base.iterate(endpoint::JSONRPCEndpoint, state = nothing)
+    if endpoint.status !== status_running
+        buffered = _take_buffered_message(endpoint)
+        buffered === nothing || return buffered, nothing
+        # Drained. A peer that simply went away ends the iteration, which is the same
+        # answer the `catch` below gives when the close lands while it is waiting.
+        endpoint.status === status_closed && endpoint.err === nothing && return nothing
+    end
     check_dead_endpoint!(endpoint)
 
     endpoint_token = CancellationTokens.get_token(endpoint.endpoint_cancellation_source)
@@ -775,6 +815,8 @@ function Base.iterate(endpoint::JSONRPCEndpoint, state = nothing)
         return take!(endpoint.in_msg_queue, endpoint_token), nothing
     catch err
         if err isa InvalidStateException || err isa CancellationTokens.OperationCanceledException
+            buffered = _take_buffered_message(endpoint)
+            buffered === nothing || return buffered, nothing
             endpoint.err !== nothing && throw(endpoint.err)
             return nothing
         else

--- a/test/test_drain_on_disconnect.jl
+++ b/test/test_drain_on_disconnect.jl
@@ -1,0 +1,107 @@
+# A peer that reports something and then goes away leaves messages the read task has already
+# parsed sitting in the (unbounded) inbound queue. Tearing the endpoint down used to make
+# those unreachable, so the last thing a peer said before exiting was lost and the caller saw
+# only the disconnect. See `JSONRPC._take_buffered_message`.
+
+@testmodule DisconnectFixture begin
+    using JSONRPC
+
+    export queue_then_disconnect
+
+    """
+    Give `server` `n` queued-but-unread messages and then take its peer away, which is the
+    state a consumer that lags its read task reaches on its own.
+    """
+    function queue_then_disconnect(server, client, client_socket, n)
+        for i in 1:n
+            JSONRPC.send_notification(client, "test/ping", Dict("i" => i))
+        end
+
+        # Wait for the read task to have parsed all of them, but read none: that is the
+        # backlog the disconnect below must not discard.
+        for _ in 1:600
+            Base.n_avail(server.in_msg_queue) == n && break
+            sleep(0.01)
+        end
+
+        close(client)
+        close(client_socket)
+
+        for _ in 1:600
+            server.status === JSONRPC.status_running || break
+            sleep(0.01)
+        end
+        return server
+    end
+end
+
+@testitem "Messages queued before a disconnect are still delivered" setup=[NamedPipes, DisconnectFixture] begin
+    socket1, socket2 = NamedPipes.get_named_pipe()
+
+    server = JSONRPC.JSONRPCEndpoint(socket1, socket1)
+    client = JSONRPC.JSONRPCEndpoint(socket2, socket2)
+
+    JSONRPC.start(server)
+    JSONRPC.start(client)
+
+    n = 5
+    DisconnectFixture.queue_then_disconnect(server, client, socket2, n)
+    @test server.status !== JSONRPC.status_running
+    @test Base.n_avail(server.in_msg_queue) == n
+
+    received = Int[]
+    for _ in 1:n
+        msg = JSONRPC.get_next_message(server)
+        @test msg.method == "test/ping"
+        push!(received, msg.params["i"])
+    end
+    @test received == collect(1:n)
+
+    # Only once there is nothing left does it report itself closed.
+    @test_throws Exception JSONRPC.get_next_message(server)
+
+    close(server)
+    close(socket1)
+end
+
+@testitem "Iterating an endpoint drains what the disconnect left behind" setup=[NamedPipes, DisconnectFixture] begin
+    socket1, socket2 = NamedPipes.get_named_pipe()
+
+    server = JSONRPC.JSONRPCEndpoint(socket1, socket1)
+    client = JSONRPC.JSONRPCEndpoint(socket2, socket2)
+
+    JSONRPC.start(server)
+    JSONRPC.start(client)
+
+    n = 3
+    DisconnectFixture.queue_then_disconnect(server, client, socket2, n)
+    @test server.status !== JSONRPC.status_running
+
+    received = Int[]
+    for msg in server
+        push!(received, msg.params["i"])
+    end
+    @test received == collect(1:n)
+
+    close(server)
+    close(socket1)
+end
+
+@testitem "A disconnect with nothing queued still reports the endpoint closed" setup=[NamedPipes, DisconnectFixture] begin
+    socket1, socket2 = NamedPipes.get_named_pipe()
+
+    server = JSONRPC.JSONRPCEndpoint(socket1, socket1)
+    client = JSONRPC.JSONRPCEndpoint(socket2, socket2)
+
+    JSONRPC.start(server)
+    JSONRPC.start(client)
+
+    DisconnectFixture.queue_then_disconnect(server, client, socket2, 0)
+    @test server.status !== JSONRPC.status_running
+
+    @test_throws Exception JSONRPC.get_next_message(server)
+    @test iterate(server) === nothing
+
+    close(server)
+    close(socket1)
+end


### PR DESCRIPTION
## The problem

`JSONRPCEndpoint.in_msg_queue` is a `Channel{Request}(Inf)`, so the read task parses messages as fast as the transport delivers them and can run far ahead of whoever consumes the endpoint. When the peer disconnects, that task's `finally` cancels `endpoint_cancellation_source` and closes the queue in one go — and every message still sitting in it became unreachable:

* `get_next_message` opened with `check_dead_endpoint!`, which throws the moment `status !== status_running`, without ever looking at the queue.
* Past that, its `take!(in_msg_queue, wait_token)` waits on the now-cancelled endpoint token, so it raised `OperationCanceledException` and got converted into `TransportError("Endpoint closed")` instead of returning the buffered element.
* `Base.iterate` had the same shape.

So the last thing a peer said before exiting was thrown away, and the caller saw only the disconnect.

## Why it matters

TestItemControllers reads test results over this endpoint. A test process that reported a result and then exited had that result dropped, leaving the controller holding the item as still-running — so it blamed that item for the crash. A **passing** test item came back as `Test process crashed while running test item 'add works'`.

It reproduced on every `ubuntu rc~x86` TestItemControllers CI run, where a slow 32 bit runner loses the consumer/producer race reliably. From that run's results artifact:

```
Test process '6a93…' is ready, dispatching test items
Test process '6a93…' terminated
Test process '6a93…' crashed (exit code 0) while running test item 'add works', erroring it immediately
Redistributing 1 un-started item(s) from crashed process '6a93…'
```

`add works` had already passed; the process then ran `exit crash`, which calls `exit()`. Faster platforms usually win the race, which is why only that one leg was red.

## The change

Hand out what is already buffered first, and only call the endpoint closed once the queue is empty as well.

* New `_take_buffered_message` does a guarded non-blocking take.
* `get_next_message` drains before `check_dead_endpoint!`, and again in its `catch` — the read task's teardown can land between the two.
* `iterate` does the same, and ends the iteration on a drained clean close rather than throwing, which is the answer it already gave when the close landed while it was waiting.

The drain only runs when the endpoint is not running, so the hot path is untouched. An idle endpoint, and one holding a `TransportError`, still throw exactly as before.

## Tests

New `test/test_drain_on_disconnect.jl`: queue N messages, wait for the read task to have parsed all of them without reading any, take the peer away, then assert all N come back before the endpoint reports itself closed — for `get_next_message` and for iteration — plus the empty case. All three fail on `main` and pass here; the full suite is 134/134 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)